### PR TITLE
feat/logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,23 +7,29 @@ RUN wget https://terraria.org/system/dedicated_servers/archives/000/000/046/orig
 RUN unzip terraria-server.zip -d terraria-server
 
 FROM debian:stable-slim
-RUN apt-get update && apt-get -y install tmux screen
+RUN apt-get update && apt-get -y install tmux screen cron logrotate
 
 ENV TERRARIA_VERSION 1423
 ENV TERRARIA_SERVER_DIR /opt/terraria/server
 ENV TERRARIA_DATA_DIR /opt/terraria/data
 
-RUN mkdir -p ${TERRARIA_SERVER_DIR} && mkdir -p ${TERRARIA_DATA_DIR}/worlds
+RUN mkdir -p ${TERRARIA_SERVER_DIR} && mkdir -p ${TERRARIA_DATA_DIR}/{worlds,logs}
 WORKDIR ${TERRARIA_SERVER_DIR}
 COPY --from=build /terraria-server/${TERRARIA_VERSION}/Linux .
 COPY ./config.txt ./config.txt
-RUN touch ./banlist.txt
 COPY ./startTerraria.sh ./startTerraria.sh
+RUN touch ./banlist.txt
+
 
 RUN groupadd --gid 1001 terraria \
-    && useradd -mg terraria --uid 1001 terraria
-RUN chown terraria:terraria -R /opt/terraria
-RUN chmod +x ./TerrariaServer.bin.x86* ./startTerraria.sh
+    && useradd -mg terraria --uid 1001 terraria \
+    && chown terraria:terraria -R /opt/terraria \
+    && chmod +x ./TerrariaServer.bin.x86* ./startTerraria.sh
+
+# Setup log rotate so logs never fill up volume.
+COPY ./terrariaLogs /etc/logrotate.d/
+RUN chmod 644 /etc/logrotate.d/terrariaLogs \
+    && chown root:root /etc/logrotate.d/terrariaLogs
 
 USER terraria
 CMD ["./startTerraria.sh"]

--- a/startTerraria.sh
+++ b/startTerraria.sh
@@ -12,9 +12,10 @@ _term() {
 cp -n ${TERRARIA_SERVER_DIR}/config.txt ${TERRARIA_DATA_DIR}
 cp -n ${TERRARIA_SERVER_DIR}/banlist.txt ${TERRARIA_DATA_DIR}
 mkdir -p ${TERRARIA_DATA_DIR}/worlds
-screen -DmS terraria bash -c "${TERRARIA_SERVER_DIR}/TerrariaServer.bin.x86_64 -config ${TERRARIA_DATA_DIR}/config.txt" &
+screen -DmS terraria -L -Logfile ${TERRARIA_DATA_DIR}/logs/terraria.log bash -c "${TERRARIA_SERVER_DIR}/TerrariaServer.bin.x86_64 -config ${TERRARIA_DATA_DIR}/config.txt" &
 pid=$!
 
 trap _term SIGTERM
 # Screen is running detached, stop docker container from exiting
+tail -f  ${TERRARIA_DATA_DIR}/logs/terraria.log &
 wait $pid

--- a/terrariaLogs
+++ b/terrariaLogs
@@ -1,0 +1,8 @@
+/opt/terraria/data/logs/terraria.log {
+        rotate 7
+        daily
+        compress
+        delaycompress
+        missingok
+        notifempty
+        create 660 linuxuser linuxuser }


### PR DESCRIPTION
Screen redirects stout to log, which we can read from d…ocker logs, or from logs located in volume.

resolves #1 